### PR TITLE
Add additional API methods to MintingKit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+name: Generate Docs
+
+on:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Pages
+      uses: actions/configure-pages@v1
+    - name: Set up Swift
+      uses: fwal/setup-swift@v1
+      with:
+        swift-version: '5.6'
+    - name: Generate Docs
+      uses: fwcd/swift-docc-action@v1
+      with:
+        target: MintingKit
+        output: ./public
+        transform-for-static-hosting: 'true'
+        disable-indexing: 'true'
+        hosting-base-path: MintingKit
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: docs
+
+    steps:
+    - name: Deploy Docs
+      uses: actions/deploy-pages@v1

--- a/Package.resolved
+++ b/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin.git",
+      "state" : {
+        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "swiftyjson",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftyJSON/SwiftyJSON.git",

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
   dependencies: [
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
     .package(url: "https://github.com/stleamist/BetterSafariView", from: "2.4.0"),
     .package(
       name: "KeychainSwift", url: "https://github.com/evgenyneu/keychain-swift", from: "20.0.0"),

--- a/Sources/MintingKit/MintingKit.swift
+++ b/Sources/MintingKit/MintingKit.swift
@@ -7,6 +7,7 @@ import SwiftyJSON
 
 let API_BASE_URL_STRING = "https://minting-api.artblocks.io"
 let ENDPOINT_URL = URL(string: API_BASE_URL_STRING)!
+let RENDER_BLOCK_CONFIRMATIONS = 3  // number of block confirmations before rendering
 
 private enum LoginError: Error {
   case tokenError(String)
@@ -22,7 +23,7 @@ public struct MKProject {
 }
 
 public struct MKMinting {
-  var blockConfirmations: Int
+  var blockConfirmations: Int?
   var shareUrl: String?
   var embedUrl: String?
   var receipt: JSON?
@@ -184,7 +185,7 @@ public struct MintingKit {
         switch response.result {
         case .success(let value):
           let json = JSON(value)
-          var mint = MKMinting(blockConfirmations: 0)
+          var mint = MKMinting()
           if let confirmations = json["block_confirmations"].int {
             mint.blockConfirmations = confirmations
           }
@@ -192,7 +193,7 @@ public struct MintingKit {
             mint.shareUrl = shareUrlString
           }
           if let urlString = json["embed_url"].string {
-            if mint.blockConfirmations >= 3 {
+            if mint.blockConfirmations >= RENDER_BLOCK_CONFIRMATIONS {
               mint.embedUrl = urlString
             }
           }

--- a/Sources/MintingKit/MintingKit.swift
+++ b/Sources/MintingKit/MintingKit.swift
@@ -5,6 +5,8 @@ import LocalAuthentication
 import SwiftUI
 import SwiftyJSON
 
+let API_BASE_URL = "https://minting-api.artblocks.io"
+
 private enum LoginError: Error {
   case tokenError(String)
 }
@@ -28,7 +30,7 @@ public struct MKMinting {
 
 public struct MintingKit {
   let token: String
-  let endpoint = URL(string: "https://minting-api.artblocks.io")!
+  let endpoint = URL(string: API_BASE_URL)!
 
   private func buildHeaders() -> HTTPHeaders {
     return [
@@ -87,7 +89,7 @@ public struct MintingKit {
     ]
     DispatchQueue.main.async {
       AF.request(
-        "https://minting-api.artblocks.io/project/\(projectId)/mintable", method: .get,
+        endpoint.appendingPathComponent("project/\(projectId)/mintable"), method: .get,
         headers: headers
       ).validate().responseJSON { response in
         switch response.result {
@@ -117,7 +119,7 @@ public struct MintingKit {
       ]
 
       AF.request(
-        "https://minting-api.artblocks.io/minting",
+        endpoint.appendingPathComponent("minting"),
         method: .post, parameters: parameters, encoding: JSONEncoding.default,
         headers: headers
       ).validate().responseJSON { response in
@@ -143,7 +145,7 @@ public struct MintingKit {
     ]
     DispatchQueue.main.async {
       AF.request(
-        "https://minting-api.artblocks.io/minting/\(mintId)", method: .get, headers: headers
+        endpoint.appendingPathComponent("minting/\(mintId)"), method: .get, headers: headers
       ).validate().responseJSON {
         response in
         switch response.result {
@@ -232,7 +234,7 @@ public struct MintingLoginButton<Label: View>: View {
     }
     .webAuthenticationSession(isPresented: $startingWebAuthenticationSession) {
       WebAuthenticationSession(
-        url: URL(string: "https://minting-api.artblocks.io/app/?appauth=true")!,
+        url: endpoint.appendingPathComponent("app/?appauth=true"),
         callbackURLScheme: "txlessauth"
       ) { callbackURL, error in
         if let t = callbackURL?.host {

--- a/Sources/MintingKit/MintingKit.swift
+++ b/Sources/MintingKit/MintingKit.swift
@@ -132,7 +132,11 @@ public struct MintingKit {
     }
   }
 
-  public func retrieveMint(mintId: String) {
+  public func retrieveMint(
+    mintId: String,
+                           onSuccess: @escaping (ABProjectMint) -> Void,
+                           onFailure: @escaping (Error) -> Void
+  ) {
     let headers: HTTPHeaders = [
       "Authorization": "Token \(token)",
       "Accept": "application/json",
@@ -160,10 +164,10 @@ public struct MintingKit {
           mint.receipt = json["receipt"]
 
           mint.isPaid = json["is_paid"].bool
+            onSuccess(mint)
         case .failure(let error):
-          print(error)
+          onFailure(mint)
         }
-        pollProject()
       }
     }
   }

--- a/Sources/MintingKit/MintingKit.swift
+++ b/Sources/MintingKit/MintingKit.swift
@@ -13,12 +13,12 @@ private enum ENSError: Error {
   case ensNotFound(String)
 }
 
-public struct ABProject {
+public struct MKProject {
   let id: String
   let title: String
 }
 
-public struct ABProjectMint {
+public struct MKMinting {
   var blockConfirmations: Int
   var shareUrl: String?
   var embedUrl: String?
@@ -38,7 +38,7 @@ public struct MintingKit {
   }
 
   public func listProjects(
-    onSuccess: @escaping ([ABProject]) -> Void, onFailure: @escaping (Error) -> Void
+    onSuccess: @escaping ([MKProject]) -> Void, onFailure: @escaping (Error) -> Void
   ) {
     AF.request(endpoint.appendingPathComponent("project"), method: .get, headers: buildHeaders())
       .validate().responseJSON { response in
@@ -46,7 +46,7 @@ public struct MintingKit {
         case .success(let value):
           let json = JSON(value)["results"].arrayValue
           let projects = json.map { project in
-            return ABProject(id: project["id"].stringValue, title: project["title"].stringValue)
+            return MKProject(id: project["id"].stringValue, title: project["title"].stringValue)
           }
           onSuccess(projects)
         case .failure(let error):
@@ -134,7 +134,7 @@ public struct MintingKit {
 
   public func retrieveMint(
     mintId: String,
-    onSuccess: @escaping (ABProjectMint) -> Void,
+    onSuccess: @escaping (MKMinting) -> Void,
     onFailure: @escaping (Error) -> Void
   ) {
     let headers: HTTPHeaders = [
@@ -149,7 +149,7 @@ public struct MintingKit {
         switch response.result {
         case .success(let value):
           let json = JSON(value)
-          var mint = ABProjectMint(blockConfirmations: 0)
+          var mint = MKMinting(blockConfirmations: 0)
           if let confirmations = json["block_confirmations"].int {
             mint.blockConfirmations = confirmations
           }

--- a/Sources/MintingKit/MintingKit.swift
+++ b/Sources/MintingKit/MintingKit.swift
@@ -108,7 +108,7 @@ public struct MintingKit {
   ) {
     DispatchQueue.main.async {
       let headers: HTTPHeaders = [
-        "Authorization": "Token " + currentToken!,
+        "Authorization": "Token " + token,
         "Accept": "application/json",
       ]
       let parameters: [String: String] = [
@@ -134,8 +134,8 @@ public struct MintingKit {
 
   public func retrieveMint(
     mintId: String,
-                           onSuccess: @escaping (ABProjectMint) -> Void,
-                           onFailure: @escaping (Error) -> Void
+    onSuccess: @escaping (ABProjectMint) -> Void,
+    onFailure: @escaping (Error) -> Void
   ) {
     let headers: HTTPHeaders = [
       "Authorization": "Token \(token)",
@@ -164,9 +164,9 @@ public struct MintingKit {
           mint.receipt = json["receipt"]
 
           mint.isPaid = json["is_paid"].bool
-            onSuccess(mint)
+          onSuccess(mint)
         case .failure(let error):
-          onFailure(mint)
+          onFailure(error)
         }
       }
     }

--- a/Sources/MintingKit/MintingKit.swift
+++ b/Sources/MintingKit/MintingKit.swift
@@ -134,7 +134,7 @@ public struct MintingKit {
     }
   }
 
-  public func retrieveMint(
+  public func retrieveMinting(
     mintId: String,
     onSuccess: @escaping (MKMinting) -> Void,
     onFailure: @escaping (Error) -> Void

--- a/Tests/MintingKitTests/MintingKitTests.swift
+++ b/Tests/MintingKitTests/MintingKitTests.swift
@@ -7,6 +7,6 @@ final class MintingKitTests: XCTestCase {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct
     // results.
-    XCTAssertEqual(MintingKit().text, "Hello, World!")
+    XCTAssertEqual(MintingKit(token: "faketoken").token, "faketoken")
   }
 }


### PR DESCRIPTION
This PR adds `mintProject` and `retrieveMint` methods to the MintingKit API.

### mintProject

The `mintProject` method accepts a project ID and a destination wallet address - with these two pieces of information, it makes a HTTPS request to the API backend to initiate minting. Success and error details are provided to the relevant supplied callbacks.

### retrieveMinting

The `retrieveMinting` method accepts a minting ID and attempts to retrieve the current status of the transaction along with relevant receipt data for updating the user interface.