### PR TITLE
Update Swift DocC documentation path for Github Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,6 @@ jobs:
         output: ./public
         transform-for-static-hosting: 'true'
         disable-indexing: 'true'
-        hosting-base-path: MintingKit
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
       with:


### PR DESCRIPTION
# Summary

This is a small one-liner change to the Github Action in this repository that generates Swift documentation from the source code of the package - it removes an unneeded config option that is preventing this package documentation site from working as expected: https://miniature-eureka-a6437639.pages.github.io/