### PR TITLE
Update README.md and rename `token` to `authToken` to disambiguate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ This documentation provides examples and information for implementing client app
 
 Before you can consume the API, you will need a user account. If you have any questions or need help setting up your account, join our Discord.
 
+### Swift Docs: https://miniature-eureka-a6437639.pages.github.io/documentation/mintingkit/mintingkit
+
+### REST API: https://minting-api.artblocks.io/docs
+
 ### Helpful Links
 
 - [Join our Discord](https://discord.com/invite/artblocks) to request a user account and talk to the Art Blocks team
-- [Log in to the dashboard](/admin/login) to manage your PBAB projects
+- [Log in to the dashboard](/admin/login) to manage your Art Blocks Engine projects
 - [View your testnet tokens](http://artist-staging.artblocks.io/) on the staging Art Blocks portal
-- [Read additional documentation](https://docs.artblocks.io/creator-docs/powered-by-art-blocks-pbab-onboarding/pbab-101/) on the PBAB API
+- [Read additional documentation](https://docs.artblocks.io/creator-docs/powered-by-art-blocks-pbab-onboarding/pbab-101/) about Art Blocks Engine
 
 ## SDK Development
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # MintingKit: Swift5 Minting API Client
 
+## Repository Status: Public Beta
+
+This code contains rapidly-changing API's, but also uses semantic versioning. Please pin the major version of the SDK you use to minimize breaking changes.
+
 This documentation provides examples and information for implementing client applications for the Powered by Art Blocks Minting Machine API.
 
 Before you can consume the API, you will need a user account. If you have any questions or need help setting up your account, join our Discord.
@@ -25,3 +29,4 @@ To get started developing this repository, you will need to perform these steps 
 4. Install pre-commit hooks: `pre-commit install`
 
 Once you have the development environment set up, you can commit code changes and run tests.
+

--- a/Sources/MintingKit/MintingKit.swift
+++ b/Sources/MintingKit/MintingKit.swift
@@ -73,11 +73,11 @@ public struct MKMinting: Codable {
 
 /**
  Provides an SDK for quickly deploying apps built on top of the Art Blocks Minting API.
- - Parameter token: The authentication token for the current user
+ - Parameter authToken: The authentication token for the current user
  */
 public struct MintingKit {
   /// The API token obtaiend for the currently-authenticated user
-  let token: String
+  let authToken: String
 
   /**
    Constructs HTTP heards for authentication and data type to make HTTP REST API calls.
@@ -85,7 +85,7 @@ public struct MintingKit {
    */
   private func buildHeaders() -> HTTPHeaders {
     return [
-      "Authorization": "Token \(token)",
+      "Authorization": "Token \(authToken)",
       "Accept": "application/json",
     ]
   }
@@ -151,7 +151,7 @@ public struct MintingKit {
     onSuccess: @escaping (Bool, String) -> Void, onFailure: @escaping (Error) -> Void
   ) {
     let headers: HTTPHeaders = [
-      "Authorization": "Token " + token,
+      "Authorization": "Token " + authToken,
       "Accept": "application/json",
     ]
     DispatchQueue.main.async {
@@ -182,7 +182,7 @@ public struct MintingKit {
   ) {
     DispatchQueue.main.async {
       let headers: HTTPHeaders = [
-        "Authorization": "Token " + token,
+        "Authorization": "Token " + authToken,
         "Accept": "application/json",
       ]
       let parameters: [String: String] = [
@@ -256,7 +256,7 @@ public struct MintingKit {
     onFailure: @escaping (Error) -> Void
   ) {
     let headers: HTTPHeaders = [
-      "Authorization": "Token \(token)",
+      "Authorization": "Token \(authToken)",
       "Accept": "application/json",
     ]
     DispatchQueue.main.async {

--- a/Tests/MintingKitTests/MintingKitTests.swift
+++ b/Tests/MintingKitTests/MintingKitTests.swift
@@ -7,6 +7,6 @@ final class MintingKitTests: XCTestCase {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct
     // results.
-    XCTAssertEqual(MintingKit(token: "faketoken").token, "faketoken")
+    XCTAssertEqual(MintingKit(token: "faketoken").authToken, "faketoken")
   }
 }


### PR DESCRIPTION
Just some small README updates and a small naming convention change.

This PR renames `token` to `authToken` when the code is referring to an authentication token to reduce the possibility of confusion with a minted token.