### PR TITLE
Update documentation path and fix broken README link

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ jobs:
       with:
         target: MintingKit
         output: ./public
+        hosting-base-path: MintingKit
         transform-for-static-hosting: 'true'
         disable-indexing: 'true'
     - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This documentation provides examples and information for implementing client app
 
 Before you can consume the API, you will need a user account. If you have any questions or need help setting up your account, join our Discord.
 
-### Swift Docs: https://miniature-eureka-a6437639.pages.github.io/documentation/mintingkit/mintingkit
+### Swift Docs: https://artblocks.github.io/MintingKit/documentation/mintingkit/mintingkit
 
 ### REST API: https://minting-api.artblocks.io/docs
 
@@ -30,4 +30,3 @@ To get started developing this repository, you will need to perform these steps 
 4. Install pre-commit hooks: `pre-commit install`
 
 Once you have the development environment set up, you can commit code changes and run tests.
-


### PR DESCRIPTION
This PR fixes a broken documentation link in the README file by updating the parameters used to generate the docs. In a followup, I will update the docs as well.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204406027794204